### PR TITLE
Update README.md with the correct script name in Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ If you already have docker installed and configured in your machine, just clone 
  ```
  **IMPORTANT!!-** This script will delete and build the container again so, make sure that you updated the Dockerfile with some configuration or package that you can't lose because, if you just installed inside the environment using `apt install` o another package handler, it'll be **LOST**.
  
- If you just want to start the environment again, use the script `run_devel.sh` 
+ If you just want to start the environment again, use the script `run_docker.sh` 
 
 ```
-$ ./run_devel.sh
+$ ./run_docker.sh
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you already have docker installed and configured in your machine, just clone 
  ```
  **IMPORTANT!!-** This script will delete and build the container again so, make sure that you updated the Dockerfile with some configuration or package that you can't lose because, if you just installed inside the environment using `apt install` o another package handler, it'll be **LOST**.
  
- If you just want to start the environment again, use the script `run_docker.sh` 
+ If you just want to start the environment again, use the script `run_devel.sh` 
 
 ```
 $ ./run_devel.sh


### PR DESCRIPTION
Looking README.md file it seems to have the following change needed.

**Actual**

If you just want to start the environment again, use the script run_docker.sh

` ./run_devel.sh`

**My change**

If you just want to start the environment again, use the script run_devel.sh

` ./run_devel.sh`